### PR TITLE
修复购物车页面 BottomBar 与 Tabbar 之间有缝隙的 bug

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -5,7 +5,7 @@ module.exports = {
       viewportHeight: 667, // 视窗的高度
       unitPrecision: 5, // 指定'px'转换为视窗单位值的小数位数
       viewportUnit: 'vw', // 指定需要转换成的视窗单位
-      selectorBlackList: ['ignore','tab-bar'], // 指定不需要转换的类
+      selectorBlackList: ['ignore','tab-bar','bottom-menu'], // 指定不需要转换的类
       minPixelValue: 1, // 小于或等于'1px'不转换为视窗单位
       mediaQuery: false, // 允许在媒体查询中转换'px'
       exclude: [/TabBar$/] // 忽略某些特定文件，不转换

--- a/src/views/cart/Cart.vue
+++ b/src/views/cart/Cart.vue
@@ -24,7 +24,7 @@ export default {
   },
   computed: {
     //将 store 中的 getter 映射到局部计算属性：
-    ...mapGetters(['cartList','cartLength'])
+    ...mapGetters(["cartList", "cartLength"]),
 
     // ...mapGetters({
     //   cartList: "cartList",
@@ -53,12 +53,10 @@ export default {
   color: #fff;
 }
 
-/*
-  .cart-list {
-    position: absolute;
-    top: 44px;
-    bottom: 49px;
-    width: 100%;
-  }
-  */
+.cart-list {
+  position: absolute;
+  top: 44px;
+  bottom: 49px;
+  width: 100%;
+}
 </style>


### PR DESCRIPTION
排除 bottom-menu 类，使得 bottom 属性有一个确定的值，即 Tabbar 的高度：49px